### PR TITLE
chore: complete REUSE tool integration

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,28 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: spartacus-bootcamp
+Source: https://github.com/SAP/spartacus-bootcamp
+Disclaimer: The code in this project may include calls to APIs (“API Calls”) of
+ SAP or third-party products or services developed outside of this project
+ (“External Products”).
+ “APIs” means application programming interfaces, as well as their respective
+ specifications and implementing code that allows software to communicate with
+ other software.
+ API Calls to External Products are not licensed under the open source license
+ that governs this project. The use of such API Calls and related External
+ Products are subject to applicable additional agreements with the relevant
+ provider of the External Products. In no event shall the open source license
+ that governs this project grant any rights in or to any External Products,or
+ alter, expand or supersede any terms of the applicable additional agreements.
+ If you have a valid license agreement with SAP for the use of a particular SAP
+ External Product, then you may make use of any API Calls included in this
+ project’s code for that SAP External Product, subject to the terms of such
+ license agreement. If you do not have a valid license agreement for the use of
+ a particular SAP External Product, then you may only make use of any API Calls
+ in this project for that SAP External Product for your internal, non-productive
+ and non-commercial test and evaluation of such API Calls. Nothing herein grants
+ you any rights to use or access any SAP External Product, or provide any third
+ parties the right to use of access any SAP External Product, through API Calls.
+
+Files: *
+Copyright: 2020-2021 SAP SE or an SAP affiliate company and spartacus-bootcamp contributors
+License: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Sample code repository for Spartacus
 
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/spartacus-bootcamp)](https://api.reuse.software/info/github.com/SAP/spartacus-bootcamp)
+
 This is a sample code repository for Spartacus. Each folder containing a `package.json` is a sample project for Spartacus.
 
 In order to try out one of the sample projects, simply navigate to the desired repository and follow the instructions in that folder's `README.md`.
@@ -22,3 +24,7 @@ Repository contains with the examples shown in OpenSAP [Introduction to "Spartac
 
 - [Spartacus source code repository](https://github.com/SAP/spartacus)
 - [Spartacus documentation site](https://sap.github.io/spartacus-docs/)
+
+## Licensing
+
+Copyright 2020-2021 SAP SE or an SAP affiliate company and spartacus-bootcamp contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/spartacus-bootcamp).


### PR DESCRIPTION
In line with SAP OSPO requirements, this PR integrates the REUSE tool

**Notes:** 
- Please [register the repository with the REUSE Tool](https://api.reuse.software/register) to complete the integration (see #16 and #17)
- This PR assumes that no third-party source code was copied in this repository. If this assumption is not correct, please change the .reuse/dep5 file accordingly. Edits by maintainers are enabled in this PR.

Fixes #15